### PR TITLE
Remove freenode and replace matrix.org channels

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,3 +1,4 @@
 Please avoid using the issue trackers to ask questions or request support. Ask
-for support in the official GrapheneOS IRC / Matrix room. It's available as
-\#grapheneos:matrix.org on Matrix and #grapheneos on irc.freenode.net.
+for support in the official GrapheneOS Matrix room. It's available at
+\#grapheneos:grapheneos.org. See https://grapheneos.org/contact for
+other channels.


### PR DESCRIPTION
Removed freenode for obvious reasons
Replaced the matrix.org channel with the grapheneos.org home server channel
Added link to grapheneos.org/contact for other channels

Don't know the Libera chat room so I just removed the IRC part entirely. Doesn't seem to be heavily used anyways.