### PR TITLE
Add hyperlink for the regular issue tracker

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,2 +1,2 @@
 Sensitive security issues can be reported to security@grapheneos.org. Please
-use the regular issue tracker if the issue does not need to be kept private.
+use the regular [issue tracker](https://github.com/GrapheneOS/os-issue-tracker/issues) if the issue does not need to be kept private.


### PR DESCRIPTION
Add hyperlink for the regular issue tracker that points to `https://github.com/GrapheneOS/os-issue-tracker/issues`.

The documentation refers to the link by the name `global OS issue tracker` (not `regular issue tracker`) and suggest using it `for GrapheneOS sub-projects`. If this is not the right place to report issues, please provide the correct hyperlink.