### PR TITLE
mark up age public key as code block

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,6 @@ Sensitive security issues can be reported to security@grapheneos.org. Please
 use the regular issue tracker if the issue does not need to be kept private.
 
 Encryption can be performed via our age public key:
-`age1dcftzgq00ykgwvxl5te6d5clqgx75h2g54c0u8gjc43mcnea7p7q3ma0yx`.
+```
+age1dcftzgq00ykgwvxl5te6d5clqgx75h2g54c0u8gjc43mcnea7p7q3ma0yx
+```


### PR DESCRIPTION
This renders the age public key with a button to copy it to the clipboard.